### PR TITLE
Changes the PiNet documentation link.

### DIFF
--- a/articles/CONTRIBUTING.md
+++ b/articles/CONTRIBUTING.md
@@ -5,29 +5,29 @@ layout: article
 
 #Contributing to the PiNet project
 
-One of the key things about the PiNet documentation is it should be easy to contribute fixes, edits or new guides to the documentation.   
-The documentation is all written in markdown, a simple, easy to to learn plain text language for formatting documents.   
-The documentation is stored in a Github repository which can be found [here](https://github.com/PiNet/PiNet-Documentation). 
-   
+One of the key things about the PiNet documentation is it should be easy to contribute fixes, edits or new guides to the documentation.
+The documentation is all written in markdown, a simple, easy to to learn plain text language for formatting documents.
+The documentation is stored in a Github repository which can be found [here](https://github.com/PiNet/PiNet.github.io). 
+
 ##I have never used markdown before
 Don't worry, it is very easy to pick up, [here is a handy guide to get your started](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
-   
+
 ##Do you have a nice text editor you recommend using to write it with?
 ![](/assets/images/atom-1.jpeg)
 
-   
-Github's own text editor, Atom is a great text editor to write markdown with, it has a nice live markdown renderer built in.   
-You can download Atom from [here](https://atom.io/).   
+
+Github's own text editor, Atom is a great text editor to write markdown with, it has a nice live markdown renderer built in.
+You can download Atom from [here](https://atom.io/).
 All the markdown files end in .html.
-Open you open a markdown file, hit ```ctrl``` + ```shift``` + ```m``` to open the markdown renderer beside the text editor.   
-   
+Open you open a markdown file, hit ```ctrl``` + ```shift``` + ```m``` to open the markdown renderer beside the text editor.
+
 ##I am completely new to Github!
 No problem, the Raspberry Pi foundation have a great getting started guide over on their [github](https://github.com/raspberrypilearning/creating-resources/blob/master/github.md).
 
 ##Ok, I have got a change or edit I want to make, what do I do?
-If it is a small edit, create a pull request ([how to do that](https://github.com/raspberrypilearning/creating-resources/blob/master/github.md)) with your change [here](https://github.com/PiNet/PiNet-Documentation/pulls).   
- If it is a new page or big edit, please open an issue first [here](https://github.com/PiNet/PiNet-Documentation/issues) (In case someone else is already doing it). 
- One of the documentation team will have a look over and decide the next step.   
- 
+If it is a small edit, create a pull request ([how to do that](https://github.com/raspberrypilearning/creating-resources/blob/master/github.md)) with your change [here](https://github.com/PiNet/PiNet.github.io/pulls).
+ If it is a new page or big edit, please open an issue first [here](https://github.com/PiNet/PiNet.github.io/issues) (In case someone else is already doing it).
+ One of the documentation team will have a look over and decide the next step.
+
 ##My edit has been accepted, now what?
-It will take 2-3 minutes for the main documentation site to update with your change. Once it has updated, check http://pi-ltsp.net and your change should be there. If the change is not there after an hour, please open an [issue](https://github.com/PiNet/PiNet-Documentation/issues).
+It will take 2-3 minutes for the main documentation site to update with your change. Once it has updated, check http://pi-ltsp.net and your change should be there. If the change is not there after an hour, please open an [issue](https://github.com/PiNet/PiNet.github.io/issues).

--- a/articles/guides.md
+++ b/articles/guides.md
@@ -4,12 +4,12 @@ layout: article
 ---
 
 ##Introduction
-PiNet is a system that has been in development for the past 2 years by [Andrew Mulholland](http://pi.gbaman.info/?page_id=90), a Computer Science student at Queens University, Belfast.   
-It was designed for schools/organisations to setup and manage Raspberry Pi networks, to replicate similar systems already in place for Windows networks.   
-The software/documentation is **completely free and open source** and has been built with guidance from educators across the world. A list of all those that have helped make this project possible can be found [here](thanks.html).   
+PiNet is a system that has been in development for the past 2 years by [Andrew Mulholland](http://pi.gbaman.info/?page_id=90), a Computer Science student at Queens University, Belfast.
+It was designed for schools/organisations to setup and manage Raspberry Pi networks, to replicate similar systems already in place for Windows networks.
+The software/documentation is **completely free and open source** and has been built with guidance from educators across the world. A list of all those that have helped make this project possible can be found [here](thanks.html).
 Note - Some documentation pages may still have mentions of Raspi-LTSP, ignore these. The site contains over 500 lines of text and over 150 images, so the upgrade may take some time.
 
-![](/assets/images/desktop-sonic-pi.jpeg)   
+![](/assets/images/desktop-sonic-pi.jpeg)
 
 ##[Getting started](installation/getting_started.html)
 ###  - [Installing Ubuntu](installation/installing-ubuntu.html)  
@@ -22,8 +22,8 @@ Note - Some documentation pages may still have mentions of Raspi-LTSP, ignore th
 ###  - [Deleting a user](manage-users/deleting-users.html)  
 ###  - [Changing a users password](manage-users/change-password.html)  
 ###  - [Userstanding staff and sudo options](manage-users/staff-sudo.html)  
-###  - [Migrating user data (for moving to a new PiNet server)](manage-users/migration.html)   
-###  - [Import users from CSV file](manage-users/csv-import.html)   
+###  - [Migrating user data (for moving to a new PiNet server)](manage-users/migration.html)
+###  - [Import users from CSV file](manage-users/csv-import.html)
 
 ##[General features](general-features.html)
 
@@ -43,7 +43,7 @@ Note - Some documentation pages may still have mentions of Raspi-LTSP, ignore th
 ###  - [Changing the default desktop and login screen background](advanced/change-background.html)
 ###  - [Changing keyboard mapping](advanced/keyboard-layout.html)
 ###  - [Understanding kernels on the Raspberry Pi and PiNet](advanced/kernels.html)
-###  - [Using SSH to connect to the Raspberry Pis](advanced/ssh-information.html)   
+###  - [Using SSH to connect to the Raspberry Pis](advanced/ssh-information.html)
 
 ##Other
 
@@ -51,8 +51,8 @@ Note - Some documentation pages may still have mentions of Raspi-LTSP, ignore th
 ###- [Frequently asked questions](faq.html)
 
 ##Contributing
-All the documentation written in markdown can be found in the [Github repository](https://github.com/PiNet/PiNet-Documentation).
-If you see **issues/typos/mistakes/etc** in this documentation please feel free to send in [pull requests](https://github.com/PiNet/PiNet-Documentation/pulls) to fix them or open an [issue](https://github.com/PiNet/PiNet-Documentation/issues).  
+All the documentation written in markdown can be found in the [Github repository](https://github.com/PiNet/PiNet.github.io).
+If you see **issues/typos/mistakes/etc** in this documentation please feel free to send in [pull requests](https://github.com/PiNet/PiNet.github.io/pulls) to fix them or open an [issue](https://github.com/PiNet/PiNet.github.io/issues).  
 If you want to **contribute** to the documentation (**please do!!**) then check out the [contributing guide](CONTRIBUTING.html)
 
 ##Support


### PR DESCRIPTION
change all https://github.com/PiNet/PiNet-Documentation to
https://github.com/PiNet/PiNet.github.io 

As https://github.com/PiNet/PiNet-Documentation leads to a 404.
