### PR TITLE
Fixes links in Contributing

### DIFF
--- a/articles/guides.md
+++ b/articles/guides.md
@@ -51,8 +51,8 @@ Note - Some documentation pages may still have mentions of Raspi-LTSP, ignore th
 ###- [Frequently asked questions](faq.html)
 
 ##Contributing
-All the documentation written in markdown can be found in the [Github repository](https://github.com/PiNet/PiNet-Documentation).
-If you see **issues/typos/mistakes/etc** in this documentation please feel free to send in [pull requests](https://github.com/PiNet/PiNet-Documentation/pulls) to fix them or open an [issue](https://github.com/PiNet/PiNet-Documentation/issues).  
+All the documentation written in markdown can be found in the [Github repository](https://github.com/PiNet/PiNet.github.io).
+If you see **issues/typos/mistakes/etc** in this documentation please feel free to send in [pull requests](https://github.com/PiNet/PiNet.github.io/pulls) to fix them or open an [issue](https://github.com/PiNet/PiNet.github.io/issues).  
 If you want to **contribute** to the documentation (**please do!!**) then check out the [contributing guide](CONTRIBUTING.html)
 
 ##Support


### PR DESCRIPTION
Changes all https://github.com/PiNet/PiNet.github.io to https://github.com/PiNet/PiNet.github.io

As the old links leads to no repository.
